### PR TITLE
Refactor Response class to buffer headers

### DIFF
--- a/tests/JsonResponseTest.php
+++ b/tests/JsonResponseTest.php
@@ -16,8 +16,24 @@ class JsonResponseTest extends TestCase
         $this->assertEquals(json_encode($response->__get()), $response->__toString());
     }
 
+    public function testWithHeaders()
+    {
+        $response = new JsonResponse();
+        $response->withHeaders(['X-Test' => 'Value']);
+
+        $reflector = new ReflectionClass($response);
+        $headersProperty = $reflector->getProperty('headers');
+        $headersProperty->setAccessible(true);
+
+        $this->assertEquals(['X-Test' => 'Value'], $headersProperty->getValue($response));
+    }
+
     public function testSend()
     {
+        if (! function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Xdebug is not installed.');
+        }
+
         $response = new JsonResponse(200, 'OK', ['body' => ['key' => 'value']]);
 
         ob_start();
@@ -26,7 +42,7 @@ class JsonResponseTest extends TestCase
 
         $this->assertEquals(json_encode($response->__get()), $output);
 
-        // Headers are hard to test
-        // $this->assertTrue(headers_sent(), 'Headers should be sent');
+        $headers = xdebug_get_headers();
+        $this->assertContains('Content-Type: application/json', $headers);
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -29,9 +29,11 @@ class ResponseTest extends TestCase
         $response = new Response();
         $response->withHeaders(['X-Test' => 'Value']);
 
-        // Headers are hard to test
-        $this->assertTrue(true);
-        // $this->assertTrue(headers_sent(), 'Headers should be sent');
+        $reflector = new ReflectionClass($response);
+        $headersProperty = $reflector->getProperty('headers');
+        $headersProperty->setAccessible(true);
+
+        $this->assertEquals(['X-Test' => 'Value'], $headersProperty->getValue($response));
     }
 
     public function testSend()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -36,6 +36,22 @@ class ResponseTest extends TestCase
         $this->assertEquals(['X-Test' => 'Value'], $headersProperty->getValue($response));
     }
 
+    public function testSendHeaders()
+    {
+        if (! function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Xdebug is not installed.');
+        }
+
+        $response = new Response(200, 'OK');
+        $response->withHeaders(['X-Test' => 'Value']);
+
+        ob_start();
+        $response->send();
+        ob_end_clean();
+
+        $this->assertContains('X-Test: Value', xdebug_get_headers());
+    }
+
     public function testSend()
     {
         $response = new Response(200, 'OK', ['body' => 'Test Body']);


### PR DESCRIPTION
## Buffer Headers in Response Class

This PR refactors the Response class to buffer headers instead of sending them immediately. This change provides more flexibility in manipulating headers throughout the response lifecycle and aligns with common practices in modern PHP frameworks.

Key changes:
- Add a protected `$headers` array to store headers in the Response class
- Modify `withHeaders()` to add headers to the buffer instead of sending them immediately
- Introduce a new `sendHeaders()` method to send all buffered headers
- Update `send()` method to call `sendHeaders()` before outputting the response body
- Adjust JsonResponse class to work with the new buffered header approach
- Update tests to reflect these changes

This improvement allows for better control over when headers are sent and enables easier modification of headers before the response is finalized.