### PR TITLE
Change response send methods to return self instead of void

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,13 @@ $response->send()->logResponse();
 
 Due to the interface change, this update is versioned as 3.0 to indicate a breaking change. Please review your codebase for any implementations of `ResponseInterface` and update them accordingly.
 
+#### Header Sending Changes
+
 1. The `withHeaders()` method now adds headers to a buffer instead of sending them immediately. If you were relying on immediate header sending, you may need to adjust your code.
 2. Headers are now sent when the `send()` method is called on the Response object. Make sure you're calling `send()` at the appropriate time in your application lifecycle.
 3. If you've extended the Response or JsonResponse classes, you may need to update your implementations to work with the new buffered header approach.
 4. Update any tests that were checking for immediate header sending. You may need to use reflection or mock the header functions to test the new buffering behavior.
+
+#### Conclusion
 
 If you encounter any issues during the upgrade process, please open an issue on the GitHub repository.

--- a/README.md
+++ b/README.md
@@ -92,36 +92,19 @@ If you're upgrading from v1.x to v2.0, here are the key changes you need to be a
 
 #### Response::send() Method Return Type
 
-1. The `send()` method in the `ResponseInterface` now has a return type of `self`. This is a breaking change.
-
+1. The `send()` method in the `ResponseInterface` now has a return type of `self`. This is a breaking change as is requires all implementing classes to update their method signature.
 2. If you have any custom classes implementing `ResponseInterface`, you must update their `send()` method to return `self`:
 
    ```php
    public function send(): self
    {
        // Your implementation
+
        return $this;
    }
    ```
 
-3. The `Response::send()` and `JsonResponse::send()` methods now return the response object itself. While this doesn't require modifications to existing code that doesn't use the return value, you can now take advantage of this change to chain methods or perform operations after sending the response if needed.
-
-Example of new usage:
-```php
-$response->send()->logResponse();
-```
-
-4. If you're type-hinting `ResponseInterface` in your code, be aware that the `send()` method now returns an instance of the response, which you can use if needed:
-
-   ```php
-   function handleResponse(ResponseInterface $response)
-   {
-       $sentResponse = $response->send();
-       // You can now use $sentResponse if needed
-   }
-   ```
-
-Due to the interface change, this update is versioned as 3.0 to indicate a breaking change. Please review your codebase for any implementations of `ResponseInterface` and update them accordingly.
+Please review your codebase for any implementations of `ResponseInterface` and update them accordingly. This change is made to allow for method chaining and provide more flexibility when working with responses, and to allow for working with sent responses in a more fluent way.
 
 #### Header Sending Changes
 

--- a/README.md
+++ b/README.md
@@ -74,17 +74,54 @@ In 99% of the cases, you forgot to call the `->send()` method on your `Response`
 
 ## Release Notes for v2.0
 
+### Breaking Changes
+- The `ResponseInterface::send()` method now returns `self` instead of `void`. This change affects the interface and all implementing classes.
+
 ### New Features
 - Headers are now buffered in the Response class instead of being sent immediately.
 - New protected `sendHeaders()` method added to the Response class for sending all buffered headers.
 
 ### Improvements
+- The `Response::send()` and `JsonResponse::send()` methods now return `$this`, allowing for method chaining and providing more flexibility when working with responses.
 - More flexibility in manipulating headers throughout the response lifecycle.
 - Better alignment with common practices in modern PHP frameworks.
 
 ### Upgrade Guide
 
 If you're upgrading from v1.x to v2.0, here are the key changes you need to be aware of:
+
+#### Response::send() Method Return Type
+
+1. The `send()` method in the `ResponseInterface` now has a return type of `self`. This is a breaking change.
+
+2. If you have any custom classes implementing `ResponseInterface`, you must update their `send()` method to return `self`:
+
+   ```php
+   public function send(): self
+   {
+       // Your implementation
+       return $this;
+   }
+   ```
+
+3. The `Response::send()` and `JsonResponse::send()` methods now return the response object itself. While this doesn't require modifications to existing code that doesn't use the return value, you can now take advantage of this change to chain methods or perform operations after sending the response if needed.
+
+Example of new usage:
+```php
+$response->send()->logResponse();
+```
+
+4. If you're type-hinting `ResponseInterface` in your code, be aware that the `send()` method now returns an instance of the response, which you can use if needed:
+
+   ```php
+   function handleResponse(ResponseInterface $response)
+   {
+       $sentResponse = $response->send();
+       // You can now use $sentResponse if needed
+   }
+   ```
+
+Due to the interface change, this update is versioned as 3.0 to indicate a breaking change. Please review your codebase for any implementations of `ResponseInterface` and update them accordingly.
 
 1. The `withHeaders()` method now adds headers to a buffer instead of sending them immediately. If you were relying on immediate header sending, you may need to adjust your code.
 2. Headers are now sent when the `send()` method is called on the Response object. Make sure you're calling `send()` at the appropriate time in your application lifecycle.

--- a/src/Contracts/ResponseInterface.php
+++ b/src/Contracts/ResponseInterface.php
@@ -8,5 +8,5 @@ interface ResponseInterface
 
     public function __toString(): string;
 
-    public function send(): void;
+    public function send(): self;
 }

--- a/src/JsonResponse.php
+++ b/src/JsonResponse.php
@@ -9,12 +9,12 @@ class JsonResponse extends Response
         return json_encode($this->responseData);
     }
 
-    public function send(): void
+    public function send(): self
     {
         $this->withHeaders([
             'Content-Type' => 'application/json',
         ]);
 
-        parent::send();
+        return parent::send();
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -40,11 +40,13 @@ class Response implements ResponseInterface
         }
     }
 
-    public function send(): void
+    public function send(): self
     {
         $this->sendHeaders();
 
         echo $this;
+
+        return $this;
     }
 
     public function __get(?string $key = null): mixed

--- a/tests/JsonResponseTest.php
+++ b/tests/JsonResponseTest.php
@@ -37,10 +37,11 @@ class JsonResponseTest extends TestCase
         $response = new JsonResponse(200, 'OK', ['body' => ['key' => 'value']]);
 
         ob_start();
-        $response->send();
+        $result = $response->send();
         $output = ob_get_clean();
 
         $this->assertEquals(json_encode($response->__get()), $output);
+        $this->assertSame($response, $result);
 
         $headers = xdebug_get_headers();
         $this->assertContains('Content-Type: application/json', $headers);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -57,10 +57,11 @@ class ResponseTest extends TestCase
         $response = new Response(200, 'OK', ['body' => 'Test Body']);
 
         ob_start();
-        $response->send();
+        $result = $response->send();
         $output = ob_get_clean();
 
         $this->assertEquals('Test Body', $output);
+        $this->assertSame($response, $result);
     }
 
     public function testMagicGet()


### PR DESCRIPTION
## Make Response::send() method return itself

This PR modifies the `Response::send()` method to return `self` instead of `void`. This change allows for method chaining and provides more flexibility when working with responses. Fixes https://github.com/caendesilva/microserve/issues/3

## Motivation

By returning the response object itself, we enable developers to perform additional operations on the response after sending it, if needed. This can be particularly useful in scenarios where you want to log or perform other actions with the response object after sending.

## Changes

- Modified `ResponseInterface::send()` method signature to return `self`
- Updated `Response::send()` method to return `self`
- Updated `JsonResponse::send()` method to return `self`
- Updated `ResponseTest` to verify the new return value

## Potential Impact

This change modifies the `ResponseInterface`, which means it's a breaking change for any classes implementing this interface. All implementations of `ResponseInterface` will need to be updated to match the new method signature.

While this change provides new possibilities for how the `send()` method can be used in applications, it requires careful consideration during upgrade due to its impact on the interface.