### PR TITLE
Use static returns instead of self

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In 99% of the cases, you forgot to call the `->send()` method on your `Response`
 ## Release Notes for v2.0
 
 ### Breaking Changes
-- The `ResponseInterface::send()` method now returns `self` instead of `void`. This change affects the interface and all implementing classes.
+- The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
 
 ### New Features
 - Headers are now buffered in the Response class instead of being sent immediately.
@@ -92,11 +92,11 @@ If you're upgrading from v1.x to v2.0, here are the key changes you need to be a
 
 #### Response::send() Method Return Type
 
-1. The `send()` method in the `ResponseInterface` now has a return type of `self`. This is a breaking change as is requires all implementing classes to update their method signature.
-2. If you have any custom classes implementing `ResponseInterface`, you must update their `send()` method to return `self`:
+1. The `send()` method in the `ResponseInterface` now has a return type of `static`. This is a breaking change as is requires all implementing classes to update their method signature.
+2. If you have any custom classes implementing `ResponseInterface`, you must update their `send()` method to return `static`:
 
    ```php
-   public function send(): self
+   public function send(): static
    {
        // Your implementation
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ In 99% of the cases, you forgot to call the `->send()` method on your `Response`
 
 ### Improvements
 - The `Response::send()` and `JsonResponse::send()` methods now return `$this`, allowing for method chaining and providing more flexibility when working with responses.
+- Type hints now use `static` returns instead of `self` to more accurately reflect the return type of the methods.
 - More flexibility in manipulating headers throughout the response lifecycle.
 - Better alignment with common practices in modern PHP frameworks.
 

--- a/src/Contracts/ResponseInterface.php
+++ b/src/Contracts/ResponseInterface.php
@@ -8,5 +8,5 @@ interface ResponseInterface
 
     public function __toString(): string;
 
-    public function send(): self;
+    public function send(): static;
 }

--- a/src/JsonResponse.php
+++ b/src/JsonResponse.php
@@ -9,7 +9,7 @@ class JsonResponse extends Response
         return json_encode($this->responseData);
     }
 
-    public function send(): self
+    public function send(): static
     {
         $this->withHeaders([
             'Content-Type' => 'application/json',

--- a/src/Response.php
+++ b/src/Response.php
@@ -23,7 +23,7 @@ class Response implements ResponseInterface
         return $this->responseData['body'];
     }
 
-    public function withHeaders(array $headers): self
+    public function withHeaders(array $headers): static
     {
         $this->headers = array_merge($this->headers, $headers);
 
@@ -40,7 +40,7 @@ class Response implements ResponseInterface
         }
     }
 
-    public function send(): self
+    public function send(): static
     {
         $this->sendHeaders();
 


### PR DESCRIPTION
Type hints now use `static` returns instead of `self` to more accurately reflect the return type of the methods.
