### PR TITLE
Update `Response::make()` to automatically send responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
               }
           }
           $app = Microserve::boot(ExampleKernel::class);
-          $app->handle()->send();
+          $app->handle();
           ' > index.php
 
       - name: Start PHP server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
                       return Response::make(200, "OK", ["body" => "Hello World!"]);
                   }
                   if ($request->path === "/json") {
-                      return new \Desilva\Microserve\JsonResponse(200, "OK", ["body" => ["message" => "Hello JSON!"]]);
+                      return (new \Desilva\Microserve\JsonResponse(200, "OK", ["body" => ["message" => "Hello JSON!"]]))->send();
                   }
                   return Response::make(404, "Not Found", ["body" => "404 Not Found"]);
               }

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Here's an example of a `server.php` script:
 require_once 'vendor/autoload.php';
 
 $app = \Desilva\Microserve\Microserve::boot(\App\Http\MyHttpKernel::class);
-$app->handle() // Process the request and create the response
-    ->send(); // Send the response to the client
+$app->handle(); // Process the request to create and send the response
 ```
 
 The `boot()` method will construct your Kernel, and then return an `Application` instance containing it.
@@ -68,14 +67,15 @@ class HttpKernel implements HttpKernelInterface
 }
 ```
 
-### Troubleshooting
-
-In 99% of the cases, you forgot to call the `->send()` method on your `Response` instance. For the other 1%, open a ticket and let me know.
+Note: If you use Response::make() it will automatically send the response to the client. 
+If you don't want this, you can instead update your kernel handle method to use `(new Response(...))`,
+and then call the `send()` method manually on the response object returned from the handle method.
 
 ## Release Notes for v2.0
 
-### Breaking Changes
-- The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
+### Breaking/Major Changes
+- Breaking: The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
+- Major: `Response::make()` now automatically sends the response. This change affects how responses are created and sent using the static `make()` method.
 
 ### New Features
 - Headers are now buffered in the Response class instead of being sent immediately.
@@ -83,6 +83,7 @@ In 99% of the cases, you forgot to call the `->send()` method on your `Response`
 
 ### Improvements
 - The `Response::send()` and `JsonResponse::send()` methods now return `$this`, allowing for method chaining and providing more flexibility when working with responses.
+- The `Response::make()` method now sends the response immediately after creating it. This fixes a common "gotcha" where users forget to call `send()` after creating a response.
 - Type hints now use `static` returns instead of `self` to more accurately reflect the return type of the methods.
 - More flexibility in manipulating headers throughout the response lifecycle.
 - Better alignment with common practices in modern PHP frameworks.
@@ -106,6 +107,25 @@ If you're upgrading from v1.x to v2.0, here are the key changes you need to be a
    ```
 
 Please review your codebase for any implementations of `ResponseInterface` and update them accordingly. This change is made to allow for method chaining and provide more flexibility when working with responses, and to allow for working with sent responses in a more fluent way.
+
+#### Response::make() Method Behavior
+
+1. The `make()` method in the `Response` class now automatically sends the response. This is a major change as it affects how responses are created and sent.
+2. If you were previously using `Response::make()->send()`, you should now use just `Response::make()` so you don't try to send the response twice.
+3. If you need to create a response without sending it immediately, use the constructor `new Response()` instead of `Response::make()`.
+
+Example of updated usage:
+
+```php
+// Old way
+$response = Response::make(200, 'OK', ['body' => 'Hello World!']);
+$response->send();
+
+// New way
+Response::make(200, 'OK', ['body' => 'Hello World!']);
+```
+
+Please review your codebase for any uses of `Response::make()` and update them accordingly. This change is made to simplify the API and provide a more intuitive way of creating and sending responses.
 
 #### Header Sending Changes
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -59,11 +59,10 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Static facade to create a new Response object.
-     * You will still need to call send() to actually send the response.
+     * Static facade to create a new Response object and send it immediately.
      */
     public static function make(int $statusCode = 200, string $statusMessage = 'OK', array $data = []): static
     {
-        return new static($statusCode, $statusMessage, $data);
+        return (new static($statusCode, $statusMessage, $data))->send();
     }
 }

--- a/tests/HttpKernelTest.php
+++ b/tests/HttpKernelTest.php
@@ -24,4 +24,16 @@ class HttpKernelTest extends TestCase
         $this->assertEquals(200, $response->statusCode);
         $this->assertEquals('Hello World!', $response->body);
     }
+
+    public function testHandleSendsResponse()
+    {
+        $kernel = $this->getMockForAbstractClass(HttpKernel::class);
+        $request = new Request();
+
+        ob_start();
+        $kernel->handle($request);
+        $output = ob_get_clean();
+
+        $this->assertEquals('Hello World!', $output);
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -79,11 +79,14 @@ class ResponseTest extends TestCase
 
     public function testMake()
     {
+        ob_start();
         $response = Response::make(201, 'Created', ['body' => 'Test Body']);
+        $output = ob_get_clean();
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(201, $response->statusCode);
         $this->assertEquals('Created', $response->statusMessage);
         $this->assertEquals('Test Body', $response->body);
+        $this->assertEquals('Test Body', $output);
     }
 }


### PR DESCRIPTION
This PR updates the `Response::make()` method to automatically send the response upon creation. This change simplifies the API by reducing the number of steps required to send a response, while still maintaining flexibility for advanced use cases.

Key changes:
- `Response::make()` now returns the result of `(new static(...))->send()`
- Updated tests to verify the new behavior

This change addresses the issue raised in #6, providing a more intuitive and streamlined way to create and send responses in Microserve. Fixes https://github.com/caendesilva/microserve/issues/6