### PR TITLE
Update the Application class to send the response instead of the make method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
                       return Response::make(200, "OK", ["body" => "Hello World!"]);
                   }
                   if ($request->path === "/json") {
-                      return (new \Desilva\Microserve\JsonResponse(200, "OK", ["body" => ["message" => "Hello JSON!"]]))->send();
+                      return new \Desilva\Microserve\JsonResponse(200, "OK", ["body" => ["message" => "Hello JSON!"]]);
                   }
                   return Response::make(404, "Not Found", ["body" => "404 Not Found"]);
               }

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Here's an example of a `server.php` script:
 require_once 'vendor/autoload.php';
 
 $app = \Desilva\Microserve\Microserve::boot(\App\Http\MyHttpKernel::class);
-$app->handle() // Process the request and create the response
-    ->send(); // Send the response to the client
+$app->handle(); // Process the request to create and send the response
 ```
 
 The `boot()` method will construct your Kernel, and then return an `Application` instance containing it.
@@ -68,14 +67,13 @@ class HttpKernel implements HttpKernelInterface
 }
 ```
 
-### Troubleshooting
-
-In 99% of the cases, you forgot to call the `->send()` method on your `Response` instance. For the other 1%, open a ticket and let me know.
+Note: The application will automatically send the response created by the Kernel.
 
 ## Release Notes for v2.0
 
-### Breaking Changes
-- The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
+### Breaking/Major Changes
+- Breaking: The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
+- Major: The Application class now automatically sends the response returned by the Kernel.
 
 ### New Features
 - Headers are now buffered in the Response class instead of being sent immediately.
@@ -83,6 +81,7 @@ In 99% of the cases, you forgot to call the `->send()` method on your `Response`
 
 ### Improvements
 - The `Response::send()` and `JsonResponse::send()` methods now return `$this`, allowing for method chaining and providing more flexibility when working with responses.
+- The application now automatically sends the response returned by the Kernel, removing the need to call `send()` manually. This fixes a common "gotcha" where users forget to call `send()` after creating a response.
 - Type hints now use `static` returns instead of `self` to more accurately reflect the return type of the methods.
 - More flexibility in manipulating headers throughout the response lifecycle.
 - Better alignment with common practices in modern PHP frameworks.
@@ -106,6 +105,27 @@ If you're upgrading from v1.x to v2.0, here are the key changes you need to be a
    ```
 
 Please review your codebase for any implementations of `ResponseInterface` and update them accordingly. This change is made to allow for method chaining and provide more flexibility when working with responses, and to allow for working with sent responses in a more fluent way.
+
+#### Response Creation and Sending
+
+The `Application` class is now responsible for sending the response after the kernel handles the request, meaning you should no longer to call `send()` manually after creating a response.
+
+Example of updated usage:
+
+```php
+// In your HttpKernel or similar class
+public function handle(Request $request): Response
+{
+    return Response::make(200, 'OK', ['body' => 'Hello World!']);
+    // OR: return new Response(200, 'OK', ['body' => 'Hello World!']);
+}
+
+// In your application entry point
+$app = new Application(new MyHttpKernel());
+$app->handle(); // This will now send the response
+```
+
+Please review your codebase for any cases where you send there responses manually, as it's no longer necessary to call `send()` after creating a response. The application will automatically send the response returned by the kernel.
 
 #### Header Sending Changes
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Here's an example of a `server.php` script:
 require_once 'vendor/autoload.php';
 
 $app = \Desilva\Microserve\Microserve::boot(\App\Http\MyHttpKernel::class);
-$app->handle(); // Process the request to create and send the response
+$app->handle() // Process the request and create the response
+    ->send(); // Send the response to the client
 ```
 
 The `boot()` method will construct your Kernel, and then return an `Application` instance containing it.
@@ -67,15 +68,14 @@ class HttpKernel implements HttpKernelInterface
 }
 ```
 
-Note: If you use Response::make() it will automatically send the response to the client. 
-If you don't want this, you can instead update your kernel handle method to use `(new Response(...))`,
-and then call the `send()` method manually on the response object returned from the handle method.
+### Troubleshooting
+
+In 99% of the cases, you forgot to call the `->send()` method on your `Response` instance. For the other 1%, open a ticket and let me know.
 
 ## Release Notes for v2.0
 
-### Breaking/Major Changes
-- Breaking: The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
-- Major: `Response::make()` now automatically sends the response. This change affects how responses are created and sent using the static `make()` method.
+### Breaking Changes
+- The `ResponseInterface::send()` method now returns `static` instead of `void`. This change affects the interface and all implementing classes.
 
 ### New Features
 - Headers are now buffered in the Response class instead of being sent immediately.
@@ -83,7 +83,6 @@ and then call the `send()` method manually on the response object returned from 
 
 ### Improvements
 - The `Response::send()` and `JsonResponse::send()` methods now return `$this`, allowing for method chaining and providing more flexibility when working with responses.
-- The `Response::make()` method now sends the response immediately after creating it. This fixes a common "gotcha" where users forget to call `send()` after creating a response.
 - Type hints now use `static` returns instead of `self` to more accurately reflect the return type of the methods.
 - More flexibility in manipulating headers throughout the response lifecycle.
 - Better alignment with common practices in modern PHP frameworks.
@@ -107,25 +106,6 @@ If you're upgrading from v1.x to v2.0, here are the key changes you need to be a
    ```
 
 Please review your codebase for any implementations of `ResponseInterface` and update them accordingly. This change is made to allow for method chaining and provide more flexibility when working with responses, and to allow for working with sent responses in a more fluent way.
-
-#### Response::make() Method Behavior
-
-1. The `make()` method in the `Response` class now automatically sends the response. This is a major change as it affects how responses are created and sent.
-2. If you were previously using `Response::make()->send()`, you should now use just `Response::make()` so you don't try to send the response twice.
-3. If you need to create a response without sending it immediately, use the constructor `new Response()` instead of `Response::make()`.
-
-Example of updated usage:
-
-```php
-// Old way
-$response = Response::make(200, 'OK', ['body' => 'Hello World!']);
-$response->send();
-
-// New way
-Response::make(200, 'OK', ['body' => 'Hello World!']);
-```
-
-Please review your codebase for any uses of `Response::make()` and update them accordingly. This change is made to simplify the API and provide a more intuitive way of creating and sending responses.
 
 #### Header Sending Changes
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -17,6 +17,6 @@ class Application
 
     public function handle(): Response
     {
-        return $this->kernel->handle($this->request);
+        return $this->kernel->handle($this->request)->send();
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -59,10 +59,11 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Static facade to create a new Response object and send it immediately.
+     * Static facade to create a new Response object.
+     * You will still need to call send() to actually send the response.
      */
     public static function make(int $statusCode = 200, string $statusMessage = 'OK', array $data = []): static
     {
-        return (new static($statusCode, $statusMessage, $data))->send();
+        return new static($statusCode, $statusMessage, $data);
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -60,7 +60,6 @@ class Response implements ResponseInterface
 
     /**
      * Static facade to create a new Response object.
-     * You will still need to call send() to actually send the response.
      */
     public static function make(int $statusCode = 200, string $statusMessage = 'OK', array $data = []): static
     {

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -27,4 +27,23 @@ class ApplicationTest extends TestCase
         $this->assertEquals(200, $response->statusCode);
         $this->assertEquals('Test Response', $response->body);
     }
+
+    public function testHandleSendsResponse()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/test';
+
+        $mockKernel = $this->createMock(HttpKernelInterface::class);
+        $mockKernel->expects($this->once())
+            ->method('handle')
+            ->willReturn(new Response(200, 'OK', ['body' => 'Test Response']));
+
+        $app = new Application($mockKernel);
+
+        ob_start();
+        $app->handle();
+        $output = ob_get_clean();
+
+        $this->assertEquals('Test Response', $output);
+    }
 }

--- a/tests/HttpKernelTest.php
+++ b/tests/HttpKernelTest.php
@@ -24,16 +24,4 @@ class HttpKernelTest extends TestCase
         $this->assertEquals(200, $response->statusCode);
         $this->assertEquals('Hello World!', $response->body);
     }
-
-    public function testHandleSendsResponse()
-    {
-        $kernel = $this->getMockForAbstractClass(HttpKernel::class);
-        $request = new Request();
-
-        ob_start();
-        $kernel->handle($request);
-        $output = ob_get_clean();
-
-        $this->assertEquals('Hello World!', $output);
-    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -79,14 +79,11 @@ class ResponseTest extends TestCase
 
     public function testMake()
     {
-        ob_start();
         $response = Response::make(201, 'Created', ['body' => 'Test Body']);
-        $output = ob_get_clean();
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(201, $response->statusCode);
         $this->assertEquals('Created', $response->statusMessage);
         $this->assertEquals('Test Body', $response->body);
-        $this->assertEquals('Test Body', $output);
     }
 }


### PR DESCRIPTION
> * Major: `Response::make()` now automatically sends the response

> Wondering if this makes things easier or not, since it now has a discrepancy with using `new Response`. Maybe it's better to have the HttpKernel send the response (or the application since the kernel is designed to be written by the user)

_Originally posted by @caendesilva in https://github.com/caendesilva/microserve/issues/11#issuecomment-2227444611_
            